### PR TITLE
Fix unambiguous typos and misspellings

### DIFF
--- a/draft-irtf-cfrg-bbs-blind-signatures.md
+++ b/draft-irtf-cfrg-bbs-blind-signatures.md
@@ -604,7 +604,7 @@ Procedure:
                                                                  api_id)
 
 5. s^ = s~ + secret_prover_blind * challenge
-6. for m in (1, 2, ..., M): m^_i = m~_i + msg_i * challenge
+6. for i in (1, 2, ..., M): m^_i = m~_i + msg_i * challenge
 
 7. proof = (s^, (m^_1, ..., m^_M), challenge)
 8. commit_with_proof = commitment_with_proof_to_octets(C, proof)

--- a/draft-irtf-cfrg-bbs-blind-signatures.md
+++ b/draft-irtf-cfrg-bbs-blind-signatures.md
@@ -790,7 +790,7 @@ Procedure:
 
 1. B = Q_1 + H_1 * msg_1 + ... + H_L * msg_L + commitment
 2. if B is Identity_G1, return INVALID
-3. return [B]
+3. return (B)
 ```
 
 ## Blind Challenge Calculation
@@ -846,7 +846,7 @@ Outputs:
 
 Procedure:
 
-1. commitment_octs = BBS.serialize([commitment])
+1. commitment_octs = BBS.serialize((commitment))
 2. if commitment_octs is INVALID, return INVALID
 3. proof_octs = BBS.serialize(proof)
 4. if proof_octs is INVALID, return INVALID

--- a/draft-irtf-cfrg-bbs-blind-signatures.md
+++ b/draft-irtf-cfrg-bbs-blind-signatures.md
@@ -251,7 +251,7 @@ Procedure:
 6. validation_res = CoreCommitVerify(commit, commit_proof,
                                                blind_generators, api_id)
 7. if validation_res is INVALID, return INVALID
-8. commitment
+8. return commit
 ```
 
 ## Blind BBS Signatures Interface
@@ -596,7 +596,7 @@ Deserialization:
 Procedure:
 
 1. (secret_prover_blind, s~, m~_1, ..., m~_M)
-                                         = BBS.get_random_scalars(M + 2)
+                                         = BBS.calculate_random_scalars(M + 2)
 2. C = Q_2 * secret_prover_blind + J_1 * msg_1 + ... + J_M * msg_M
 3. Cbar = Q_2 * s~ + J_1 * m~_1 + ... + J_M * m~_M
 
@@ -790,7 +790,7 @@ Procedure:
 
 1. B = Q_1 + H_1 * msg_1 + ... + H_L * msg_L + commitment
 2. if B is Identity_G1, return INVALID
-3. return B
+3. return [B]
 ```
 
 ## Blind Challenge Calculation
@@ -846,14 +846,14 @@ Outputs:
 
 Procedure:
 
-1. commitment_octs = BBS.serialize(commitment)
+1. commitment_octs = BBS.serialize([commitment])
 2. if commitment_octs is INVALID, return INVALID
 3. proof_octs = BBS.serialize(proof)
 4. if proof_octs is INVALID, return INVALID
 5. return commitment_octs || proof_octs
 ```
 
-### Octet to Commitment with Proof
+### Octets to Commitment with Proof
 
 ```
 commitment = octets_to_commitment_with_proof(commitment_octs)
@@ -879,7 +879,7 @@ Procedure:
 2.  if length(commitment_octs) < commit_len_floor, return INVALID
 
 3.  C_octets = commitment_octs[0..(octet_point_length - 1)]
-4.  C = octets_to_point_g1(C_octets)
+4.  C = octets_to_point_E1(C_octets)
 5.  if C is INVALID, return INVALID
 6.  if C == Identity_G1, return INVALID
 
@@ -887,15 +887,15 @@ Procedure:
 8.  index = octet_point_length
 9.  while index < length(commitment_octs):
 10.     end_index = index + octet_scalar_length - 1
-11.     s_j = OS2IP(commitment_octets[index..end_index])
+11.     s_j = OS2IP(commitment_octs[index..end_index])
 12.     if s_j = 0 or if s_j >= r, return INVALID
 13.     index += octet_scalar_length
 14.     j += 1
 
 15. if index != length(commitment_octs), return INVALID
 16. if j < 2, return INVALID
-17. msg_commitment = ()
-18. if j >= 3, set msg_commitment = (s_2, ..., s_(j-1))
+17. msg_commitments = ()
+18. if j >= 3, set msg_commitments = (s_1, ..., s_(j-1))
 19. return (C, (s_0, msg_commitments, s_j))
 ```
 

--- a/draft-irtf-cfrg-bbs-blind-signatures.md
+++ b/draft-irtf-cfrg-bbs-blind-signatures.md
@@ -604,7 +604,7 @@ Procedure:
                                                                  api_id)
 
 5. s^ = s~ + secret_prover_blind * challenge
-6. for m in (1, 2, ..., M): m^_i = m~_1 + msg_i * challenge
+6. for m in (1, 2, ..., M): m^_i = m~_i + msg_i * challenge
 
 7. proof = (s^, (m^_1, ..., m^_M), challenge)
 8. commit_with_proof = commitment_with_proof_to_octets(C, proof)


### PR DESCRIPTION
- Missing `return` keyword in `deserialize_and_validate_commit`
- `BBS.calculate_random_scalars` misspelled as `BBS.get_random_scalars`
- `B_calculate` procedure needs to return an array
- `BBS.serialize` argument needs to be an array
- Section heading "Octet to Commitment with Proof" should be plural "Octets"
- `octets_to_point_E1` misspelled as `octets_to_point_g1`
- Variable `commitment_octs` referenced as `commitment_octets` once in `octets_to_commitment_with_proof`
- Variable `octets_to_commitment_with_proof` spelled as both `msg_commitment` and `msg_commitments`