### PR TITLE
Fix M offsets in BlindSign to agree with octets_to_commitment_with_proof

### DIFF
--- a/draft-irtf-cfrg-bbs-blind-signatures.md
+++ b/draft-irtf-cfrg-bbs-blind-signatures.md
@@ -308,7 +308,7 @@ Deserialization:
 // calculate the number of blind generators used by the commitment,
 // if any.
 2. M = length(commitment_with_proof)
-3. if M != 0, M = M - octet_point_length - octet_scalar_length
+3. if M != 0, M = M - octet_point_length - 2 * octet_scalar_length
 4. M = M / octet_scalar_length
 5. if M < 0, return INVALID
 


### PR DESCRIPTION
Without this, the 4 [BLS12-381-SHA-256 signature test vectors][1] with a commitment all fail to reproduce because `deserialize_and_validate_commit` fails at

```
5. if length(commit_proof[1]) + 1 != length(blind_generators),
                                                          return INVALID
```

because `BlindSign` computes a too high `M` and therefore creates too many `blind_generators`.

[1]: https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-blind-signatures-02.html#name-signature-test-vectors