### PR TITLE
Fix computation of B and domain to agree with test vector traces

### DIFF
--- a/draft-irtf-cfrg-bbs-blind-signatures.md
+++ b/draft-irtf-cfrg-bbs-blind-signatures.md
@@ -702,7 +702,7 @@ Deserialization:
 
 Procedure:
 
-1. domain = BBS.calculate_domain(PK, Q_1, (H_1, ..., H_L, J_1, ..., J_M),
+1. domain = BBS.calculate_domain(PK, Q_1, (H_1, ..., H_L, Q_2, J_1, ..., J_M),
                                                          header, api_id)
 2. e_octs = BBS.serialize((SK, B, domain))
 3. e = BBS.hash_to_scalar(e_octs, signature_dst)
@@ -788,7 +788,7 @@ Deserialization:
 
 Procedure:
 
-1. B = Q_1 + H_1 * msg_1 + ... + H_L * msg_L + commitment
+1. B = P1 + Q_1 * domain + H_1 * msg_1 + ... + H_L * msg_L + commitment
 2. if B is Identity_G1, return INVALID
 3. return B
 ```


### PR DESCRIPTION
`domain` needs to include `Q_2` since this `domain` value will be verified by `BBS.CoreVerify`, which doesn't consider `Q_2` special and therefore won't omit this generator from the domain computation.

`B` similarly needs to include `P1` (like `BBS.CoreSign` and `BBS.ProofInit` do) since this value will be independently reconstructed (sort of) by `BBS.CoreVerify` and `BBS.ProofVerifyInit` as part of signature and proof verification.

Without this, the `FinalizeBlindSign` and `B_calculate` procedures fail to reproduce the `B` and `domain` values stated as "Trace" in the [BLS12-381-SHA-256 signature test vectors][1] (and therefore also fail to reproduce the signatures).

[1]: https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-blind-signatures-02.html#name-signature-test-vectors