### PR TITLE
Fix proof_len_floor in BlindProofVerify

### DIFF
--- a/draft-irtf-cfrg-bbs-blind-signatures.md
+++ b/draft-irtf-cfrg-bbs-blind-signatures.md
@@ -538,7 +538,7 @@ Outputs:
 
 Deserialization:
 
-1. proof_len_floor = 2 * octet_point_length + 3 * octet_scalar_length
+1. proof_len_floor = 3 * octet_point_length + 4 * octet_scalar_length
 2. if length(proof) < proof_len_floor, return INVALID
 3. U = floor((length(proof) - proof_len_floor) / octet_scalar_length)
 4. total_no_messages = length(disclosed_indexes) +


### PR DESCRIPTION
`proof` is forwarded verbatim to `BBS.CoreProofVerify`, where `octets_to_proof` requires `proof_len_floor = 3 * octet_point_length + 4 * octet_scalar_length`.

Indeed, all 8 [BLS12-381-SHA-256 test vectors][1] fail to verify without changing these to 3 and 4, because they compute a too high `U` value in`BlindProofVerify` and therefore create too many generators, which is then rejected by `BBS.CoreProofVerify` because the number of generators does not match the number of messages.

[1]: https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-blind-signatures-02.html#name-bls12-381-sha-256