### PR TITLE
Add native key binding

### DIFF
--- a/draft-irtf-cfrg-bbs-blind-signatures.md
+++ b/draft-irtf-cfrg-bbs-blind-signatures.md
@@ -176,7 +176,7 @@ Notation defined by [@!I-D.irtf-cfrg-bbs-signatures] applies to this draft.
 Additionally, the following notation and primitives are used:
 
 list.append(elements)
-: Append either a single element or a list of elements to the end of a list, maintaining the same order of the list's elements as well as the appended elements. For example, given `list = [a, b, c]` and `elements = [d, a]`, the result of `list.append(elements)` will be `[a, b, c, d, a]`.
+: Append either a single element or a list of elements to the end of a list, maintaining the same order of the list's elements as well as the appended elements. For example, given `list = [a, b, c]` and `elements = [d, a]`, the result of `list.append(elements)` will be `[a, b, c, d, a]`. Neither original list is modified.
 
 # Conventions
 
@@ -184,10 +184,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 # BBS Signature Scheme Operations
 
-This document makes use of various operations defined by the BBS Signature Scheme document [@!I-D.irtf-cfrg-bbs-signatures]. For clarity, whenever an operation will be used defined in [@!I-D.irtf-cfrg-bbs-signatures], it will be prefixed by "BBS." (e.g., "BBS.CoreVerify" etc.). More specifically, the operations used are the following:
+This document makes use of various operations defined by the BBS Signature Scheme document [@!I-D.irtf-cfrg-bbs-signatures]. For clarity, whenever an operation will be used defined in [@!I-D.irtf-cfrg-bbs-signatures], it will be prefixed by "BBS." (e.g., "BBS.ProofInit" etc.). More specifically, the operations used are the following:
 
 - `BBS.octets_to_point_E1`: Refers to the `octets_to_point_E1` operation defined in [@!I-D.irtf-cfrg-bbs-signatures, section 1.2].
-- `BBS.CoreVerify`: Refers to the `CoreVerify` operation defined in [@!I-D.irtf-cfrg-bbs-signatures, section 3.6.2].
 - `BBS.ProofInit`: Refers to the `ProofInit` operation defined in [@!I-D.irtf-cfrg-bbs-signatures, section 3.7.1].
 - `BBS.ProofFinalize`: Refers to the `ProofFinalize` operation defined in [@!I-D.irtf-cfrg-bbs-signatures, section 3.7.2].
 - `BBS.ProofVerifyInit`: Refers to the `ProofVerifyInit` operation defined in [@!I-D.irtf-cfrg-bbs-signatures, section 3.7.3].
@@ -203,6 +202,33 @@ This document makes use of various operations defined by the BBS Signature Schem
 
 
 # Scheme Definition
+
+This scheme extends the BBS ciphersuite as defined in [I-D.irtf-cfrg-bbs-signatures]
+with an additional parameter: an optional key binding signature scheme `Sig` consisting of the following procedures and constants:
+
+`Sig.KeyGen(Hk) -> (SK, PK)`
+: Generate a key pair with private key `SK` and public key `PK = SK * Hk` with generator `Hk` in G1.
+
+`Sig.Sign(Hk, SK, message) -> sig`
+: Generate a signature `sig` on `message` using private key `SK` and public key generator `Hk`.
+
+`Sig.Verify(Hk, PK, sig, message) -> VALID or INVALID`
+: Return VALID if `sig` is a valid signature on `message` for public key `PK` with generator `Hk`, otherwise INVALID.
+
+`Sig.AdaptSig(sig, r_key, message) -> sig'`
+: Compute an adapted signature `sig'` such that if `sig` is a valid signature on `message` for public key `PK = SK * Hk`,
+  then `sig'` is a valid signature on `message` for public key `PK + Hk * r_key`.
+
+`Sig.signature_length`
+: A nonnegative integer equal to the length of signature octet strings output by `Sig.Sign`.
+
+The parameter `Hk` MUST be either the standard generator BP1 as defined in [@!I-D.irtf-cfrg-bbs-signatures, section 1.2]
+or one of the points of `BBS.create_generators(K, "KEYBIND_" || api_id)`
+for arbitrary `K` and `api_id` defined by the ciphersuite.
+
+A ciphersuite that does not define `Sig` implicitly has a `Sig` scheme whose procedures all unconditionally return INVALID
+and whose `Sig.signature_length = 0`.
+
 
 ## Commitment Operations
 
@@ -235,6 +261,50 @@ Outputs:
 
 Procedure:
 
+1. (state, secret_prover_blind, challenge) = CommitInit(committed_messages, ())
+2. commitment_with_proof = CommitFinalize(state, ())
+3. return (commitment_with_proof, secret_prover_blind)
+```
+
+#### Commitment Initialization
+
+This operation is used by the Prover to create a commitment including commitments to public keys for key binding.
+TODO: Update description
+
+ISSUE: [@DBAC2025] only models 1 device binding key, while this models 0..K
+`keybind_public_keys`. Without further research this will need to be limited to K=0..1.
+
+```
+(commitment_state, secret_prover_blind, challenge)
+  = CommitInit(committed_messages, keybind_public_keys, api_id)
+
+Inputs:
+
+- committed_messages (OPTIONAL), a vector of octet strings. If not
+                                 supplied it defaults to the empty
+                                 array ("()").
+- keybind_public_keys (OPTIONAL), a vector of octet strings. If not
+                                  supplied it defaults to the empty
+                                  array ("()").
+- api_id (OPTIONAL), octet string. If not supplied it defaults to the
+                     empty octet string ("").
+
+Outputs:
+
+- (commitment_state, secret_prover_blind, challenge),
+              a tuple comprised from an octet string, a random scalar
+              and an octet string in that order.
+
+Deserialization:
+
+1. K = length(keybind_public_keys)
+2. for i in (1..K)
+3.     PK_i = BBS.octets_to_point_E1(keybind_public_keys[i - 1])
+4.     if PK_i is INVALID, return INVALID
+5.     if PK_i == Identity_G1, return INVALID
+
+Procedure:
+
 1. committed_message_scalars = BBS.messages_to_scalars(
                                              committed_messages, api_id)
 
@@ -242,8 +312,52 @@ Procedure:
                                   length(committed_message_scalars) + 1,
                                   "BLIND_" || api_id)
 
-3. return CoreCommit(blind_generators,
-                             committed_message_scalars, api_id)
+3. keybind_generators = BBS.create_generators(K, "KEYBIND_" || api_id)
+
+4. (state, secret_prover_blind, challenge) = CoreCommitInit(
+      blind_generators.append(keybind_generators),
+      committed_message_scalars,
+      (PK_1, ..., PK_K),
+      api_id)
+5. return (commitment_state_to_octets(state), secret_prover_blind,
+           BBS.serialize((challenge)))
+```
+
+#### Commitment Finalization
+
+TODO: Description
+
+```
+commitment_with_proof = CommitFinalize(state, keybind_proofs, api_id)
+
+Inputs:
+
+- state,                     an octet string in the format
+                             outputted by the first output of
+                             CommitInit.
+- keybind_signatures (OPTIONAL), a vector of octet strings. If not
+                                 supplied it defaults to the empty
+                                 array ("()").
+- api_id (OPTIONAL), octet string. If not supplied it defaults to the
+                     empty octet string ("").
+
+Outputs:
+
+- commitment_with_proof, an octet string.
+
+Deserialization:
+
+1. state_res = octets_to_commitment_state(state)
+2. if state_res is INVALID, return INVALID
+3. (C, s^, m^, challenge, keybind_public_keys) = state_res
+4. K = length(keybind_public_keys)
+5. if length(keybind_signatures) != K, return INVALID
+
+Procedure:
+
+1. (commitment, commitment_proof) = CoreCommitFinalize(
+       state_res, keybind_signatures)
+2. return commitment_with_proof_to_octets(commitment, commitment_proof)
 ```
 
 ### Commitment Validation and Deserialization
@@ -251,39 +365,40 @@ Procedure:
 The following is a helper operation used by the `BlindSign` procedure ((#blind-signature-generation)) to validate an optional commitment. If a `commitment` is not supplied, or if it is the `Identity_G1`, the following operation will return the `Identity_G1` as the "default" commitment point, which will be ignored by all computations during `BlindSign`.
 
 ```
-commitment = deserialize_and_validate_commit(commitment_with_proof,
-                                               blind_generators, api_id)
+(commitment, blind_generators)
+  = deserialize_and_validate_commit(commitment_with_proof, api_id)
 
 Inputs:
 
 - commitment_with_proof (OPTIONAL), octet string. If it is not supplied
                                     it defaults to the empty octet
                                     string ("").
-- blind_generators (OPTIONAL), vector of points of G1. If it is not
-                               supplied it defaults to the empty set
-                               ("()").
 - api_id (OPTIONAL), octet string. If not supplied it defaults to the
                      empty octet string ("").
 
 Outputs:
 
-- commitment, a point of G1; or INVALID.
+- commitment, a point of G1 and a vector of points of G1; or INVALID.
+- blind_generators, vector of points of G1.
 
 Procedure:
 
-1. if commitment_with_proof is the empty string (""), return Identity_G1
+1.  if commitment_with_proof is the empty string (""),
+        return (Identity_G1, BBS.create_generators(1, "BLIND_" || api_id))
 
-2. com_res = octets_to_commitment_with_proof(commitment_with_proof)
-3. if com_res is INVALID, return INVALID
+2.  com_res = octets_to_commitment_with_proof(commitment_with_proof)
+3.  if com_res is INVALID, return INVALID
 
-4. (commitment, commitment_proof) = com_res
-5. if length(commitment_proof[1]) + 1 != length(blind_generators),
-                                                          return INVALID
+4.  ((commitment, keybind_public_keys), commitment_proof) = com_res
+5.  (s^, m^, challenge, keybind_signatures) = commitment_proof
+6.  blind_generators = BBS.create_generators(length(m^) + 1, "BLIND_" || api_id)
+7.  keybind_generators = BBS.create_generators(length(keybind_signatures), "KEYBIND_" || api_id)
+8.  generators = blind_generators.append(keybind_generators)
 
-6. validation_res = CoreCommitVerify(commitment, commitment_proof,
-                                               blind_generators, api_id)
-7. if validation_res is INVALID, return INVALID
-8. return commitment
+9.  validation_res = CoreCommitVerify(commitment, keybind_public_keys, commitment_proof,
+                                      generators, api_id)
+10. if validation_res is INVALID, return INVALID
+11. return (commitment, generators)
 ```
 
 ## Blind BBS Signatures Interface
@@ -310,8 +425,8 @@ Inputs:
                  provided the above SK as input.
 - commitment_with_proof (OPTIONAL), an octet string, representing a
                                     serialized commitment and
-                                    commitment_proof, as the first
-                                    element outputted by the Commit
+                                    commitment_proof, in the format
+                                    outputted by the CommitFinalize
                                     operation. If not supplied, it
                                     defaults to the empty string ("").
 - header (OPTIONAL), an octet string containing context and application
@@ -332,47 +447,40 @@ Outputs:
 - blind_signature, a blind signature encoded as an octet string; or
                    INVALID.
 
-
 Deserialization:
 
-1. L = length(messages)
+1.  L = length(messages)
+2.  deserialize_res = deserialize_and_validate_commit(commitment_with_proof, api_id)
+3.  if deserialize_res is INVALID, return INVALID
+4.  ((commitment, keybind_public_keys), blind_generators) = deserialize_res
 
-// calculate the number of blind generators used by the commitment,
-// if any.
-2. M = length(commitment_with_proof)
-3. if M != 0, M = M - octet_point_length - 2 * octet_scalar_length
-4. M = M / octet_scalar_length
-5. if M < 0, return INVALID
+5.  K = length(keybind_public_keys)
+6.  (PK_1, ..., PK_K) = keybind_public_keys
 
 Procedure:
 
-1.  generators = BBS.create_generators(L + 1, api_id)
-2.  blind_generators = BBS.create_generators(M + 1, "BLIND_" || api_id)
+1. message_scalars = BBS.messages_to_scalars(messages, api_id)
+2. generators = BBS.create_generators(L + 1, api_id)
 
-3.  commitment = deserialize_and_validate_commit(commitment_with_proof,
-                                               blind_generators, api_id)
-4.  if commitment is INVALID, return INVALID
+3. res = B_calculate(PK, generators, blind_generators,
+             commitment + PK_1 + ... + PK_K, message_scalars, header, api_id)
+4. if res is INVALID, return INVALID
+5. (B) = res
 
-5.  message_scalars = BBS.messages_to_scalars(messages, api_id)
-
-6.  res = B_calculate(PK, generators, blind_generators, commitment, message_scalars, header, api_id)
-7.  if res is INVALID, return INVALID
-8.  (B) = res
-
-9.  blind_sig = FinalizeBlindSign(SK, B, api_id)
-10. if blind_sig is INVALID, return INVALID
-11. return blind_sig
+6. blind_sig = FinalizeBlindSign(SK, B, api_id)
+7. if blind_sig is INVALID, return INVALID
+8. return blind_sig
 ```
 
 ### Blind Signature Verification
 
 This operation validates a blind BBS signature (`signature`), given the Signer's public key (`PK`), a header (`header`), a set of messages (`messages`), including first the messages chosen by the Issuer and then the ones chosen (and committed to) by the Prover and if used, the `secret_prover_blind` as returned by the `Commit` operation ((#commitment-computation)).
 
-This operation makes use of the `CoreVerify` operation as defined in [@!I-D.irtf-cfrg-bbs-signatures, section 3.6.2].
+This operation makes use of the `CoreVerify` operation as defined in (#CoreVerify).
 
 ```
-result = VerifyBlindSign(PK, signature, header, messages,
-                          issuer_known_messages_no, secret_prover_blind)
+result = VerifyBlindSign(PK, signature, header, messages, issuer_known_messages_no,
+                         keybind_public_keys,secret_prover_blind)
 
 Inputs:
 
@@ -387,6 +495,8 @@ Inputs:
                        defaults to the empty array "()".
 - issuer_known_messages_no (OPTIONAL), a non-negative integer. If not
                                        supplied, it defaults to 0.
+- keybind_public_keys (OPTIONAL), a vector of octet strings. If not
+                       supplied, it defaults to the empty array "()".
 - secret_prover_blind (OPTIONAL), a scalar value. If not supplied it
                                   defaults to zero "0".
 
@@ -405,29 +515,36 @@ Deserialization:
 
 1. L = length(messages)
 2. if issuer_known_messages_no > L, return INVALID
+3. K = length(keybind_public_keys)
+4. for i in (1..K)
+5.     PK_i = BBS.octets_to_point_E1(keybind_public_keys[i-1])
+6.     if PK_i is INVALID, return INVALID
+7.     if PK_i == Identity_G1, return INVALID
 
 Procedure:
 
 1. generators = BBS.create_generators(issuer_known_messages_no + 1, api_id)
 2. blind_generators = BBS.create_generators(
                    L - issuer_known_messages_no + 1, "BLIND_" || api_id)
+3. keybind_generators = BBS.create_generators(K, "KEYBIND_" || api_id)
 
-3. message_scalars = BBS.messages_to_scalars(messages, api_id)
+4. message_scalars = BBS.messages_to_scalars(messages, api_id)
 
-4. signer_scalars = (message_scalars[0], ...,
+5. signer_scalars = (message_scalars[0], ...,
                           message_scalars[issuer_known_messages_no - 1])
-5. committed_message_scalars = (message_scalars[issuer_known_messages_no], ...,
+6. committed_message_scalars = (message_scalars[issuer_known_messages_no], ...,
                                             message_scalars[L - 1])
-6. proof_scalars = signer_scalars.append(secret_prover_blind)
+7. proof_scalars = signer_scalars.append(secret_prover_blind)
                                           .append(committed_message_scalars)
 
-7. res = BBS.CoreVerify(PK,
-                        signature,
-                        generators.append(blind_generators),
-                        header,
-                        proof_scalars,
-                        api_id)
-8. return res
+8. res = CoreVerify(PK,
+                    signature,
+                    generators.append(blind_generators).append(keybind_generators),
+                    header,
+                    proof_scalars,
+                    (PK_1, ..., PK_K),
+                    api_id)
+9. return res
 ```
 
 ### Proof Generation
@@ -447,7 +564,7 @@ The operation will accept a set of messages (`messages`), including first the me
 
 Furthermore, the operation also expects the `secret_prover_blind` (as returned from the `Commit` operation defined in (#commitment-computation)) value. If the BBS signature is generated using a commitment value, then the `secret_prover_blind` returned by the `Commit` operation used to generate the commitment should be provided to the `ProofGen` operation (otherwise the resulting proof will be invalid).
 
-This operation makes use of the `CoreProofGen` operation as defined in (#core-proof-generation).
+This operation makes use of the `CoreProofGenInit` operation as defined in (#core-proof-generation-initialization).
 
 The operation will also accept a map `message_disclosures` between each message index and one of the three values `DISCLOSE`, `HIDE` and `COMMIT`. A `{i: DISCLOSE}` (key, value) pair indicates that `messages[i]` will be revealed to the Verifier. Correspondingly, a `{i: HIDE}` (key, value) pair indicates that `messages[i]` will not be disclosed to the Verifier. Finally, a `{i: COMMIT}` (key, value) pair indicates that only a commitment to `messages[i]` will be disclosed to the Verifier.
 
@@ -514,53 +631,183 @@ Outputs:
                 used in committed disclosure, and the array of random scalars
                 used to create the respective commitments.
 
+Procedure:
+
+1. (state, add_zkp_info, keybind_challenges) = BlindProofGenInit(
+       PK,
+       signature,
+       header,
+       ph,
+       messages,
+       issuer_known_messages_no,
+       message_disclosures,
+       (),
+       secret_prover_blind)
+
+2. proof = BlindProofGenFinalize(state, ())
+3. return (proof, add_zkp_info)
+```
+
+
+### Proof Generation Initialization
+
+TODO: Description
+
+```
+[proof, add_zkp_info] = BlindProofGenInit(
+    PK,
+    signature,
+    header,
+    ph,
+    messages,
+    issuer_known_messages_no,
+    message_disclosures,
+    keybind_public_keys,
+    secret_prover_blind)
+
+Inputs:
+
+- PK (REQUIRED), an octet string of the form outputted by the SkToPk
+                 operation.
+- signature (REQUIRED), an octet string of the form outputted by the
+                        Sign operation.
+- header (OPTIONAL), an octet string containing context and application
+                     specific information. If not supplied, it defaults
+                     to an empty string.
+- ph (OPTIONAL), an octet string containing the presentation header. If
+                 not supplied, it defaults to an empty string.
+- messages (OPTIONAL), a vector of octet strings. If not supplied, it
+                       defaults to the empty array "()".
+- issuer_known_messages_no (OPTIONAL), a non-negative integer. If not
+                                       supplied, it defaults to 0.
+- message_disclosures (OPTIONAL), a map between message indexes and one
+                                   of the DISCLOSE, HIDE or COMMIT
+                                   values. If not supplied, it defaults
+                                   to the empty map "{}".
+- keybind_public_keys (OPTIONAL), a vector of octet strings. If not
+                                  supplied, it defaults to the empty
+                                  array "()".
+- secret_prover_blind (OPTIONAL), a scalar value. If not supplied it
+                                  defaults to zero "0".
+
+
+Parameters:
+
+- api_id, the octet string ciphersuite_id || "BLIND_H2G_HM2S_", where
+          ciphersuite_id is defined by the ciphersuite and
+          "BLIND_H2G_HM2S_"is an ASCII string composed of 15 bytes.
+
+Outputs:
+
+- state, an octet string; or INVALID.
+- add_zkp_info, a structure containing an array of committed message scalars
+                used in committed disclosure, and the array of random scalars
+                used to create the respective commitments.
+- keybind_challenges, a vector of octet strings.
+
 Deserialization:
 
-1. L = length(messages)
-2. if length(message_disclosures) != L, return INVALID
-3. if issuer_known_messages_no > L, return INVALID
-4. if the keys of message_disclosures are not exactly the integers
-   0..L - 1, return INVALID
-5. if any value in message_disclosures is not one of DISCLOSE, HIDE,
-   or COMMIT, return INVALID
+1.  L = length(messages)
+2.  if length(message_disclosures) != L, return INVALID
+3.  if issuer_known_messages_no > L, return INVALID
+4.  if the keys of message_disclosures are not exactly the integers
+    0..L - 1, return INVALID
+5.  if any value in message_disclosures is not one of DISCLOSE, HIDE,
+    or COMMIT, return INVALID
 
-6. let disclosed_indexes be the integers i in 0..L - 1 so
-   that message_disclosures[i] = DISCLOSE, in
-   ascending order.
-7. let commitment_indexes be the integers i in 0..L - 1 so
-   that message_disclosures[i] = COMMIT, in
-   ascending order.
+6.  let disclosed_indexes be the integers i in 0..L - 1 so
+    that message_disclosures[i] = DISCLOSE, in
+    ascending order.
+7.  let commitment_indexes be the integers i in 0..L - 1 so
+    that message_disclosures[i] = COMMIT, in
+    ascending order.
+
+8.  K = length(keybind_public_keys)
+9.  for i in (1..K)
+10.     PK_i = BBS.octets_to_point_E1(keybind_public_keys[i - 1])
+11.     if PK_i is INVALID, return INVALID
+12.     if PK_i == Identity_G1, return INVALID
 
 Procedure:
 
-1. generators = BBS.create_generators(
-                                  issuer_known_messages_no + 1, api_id)
-2. blind_generators = BBS.create_generators(
-                   L - issuer_known_messages_no + 1, "BLIND_" || api_id)
+1.  generators = BBS.create_generators(
+                                   issuer_known_messages_no + 1, api_id)
+2.  blind_generators = BBS.create_generators(
+                    L - issuer_known_messages_no + 1, "BLIND_" || api_id)
+3.  keybind_generators = BBS.create_generators(K, "KEYBIND_" || api_id)
 
-3. message_scalars = BBS.messages_to_scalars(messages, api_id)
+4.  message_scalars = BBS.messages_to_scalars(messages, api_id)
 
-4. signer_scalars = (message_scalars[0], ...,
-                          message_scalars[issuer_known_messages_no - 1])
-5. committed_message_scalars = (message_scalars[issuer_known_messages_no], ...,
-                                            message_scalars[L - 1])
-6. proof_scalars = signer_scalars.append(secret_prover_blind)
-                                          .append(committed_message_scalars)
-7. let proof_index(i) be i if i < issuer_known_messages_no,
-   and i + 1 otherwise.
-8. proof_disclosed_indexes = (proof_index(i) for i in disclosed_indexes)
-9. proof_commitment_indexes = (proof_index(i) for i in commitment_indexes)
+5.  signer_scalars = (message_scalars[0], ...,
+                           message_scalars[issuer_known_messages_no - 1])
+6.  committed_message_scalars = (message_scalars[issuer_known_messages_no], ...,
+                                             message_scalars[L - 1])
+7.  proof_scalars = signer_scalars.append(secret_prover_blind)
+                                           .append(committed_message_scalars)
+8.  let proof_index(i) be i if i < issuer_known_messages_no,
+    and i + 1 otherwise.
+9.  proof_disclosed_indexes = (proof_index(i) for i in disclosed_indexes)
+10. proof_commitment_indexes = (proof_index(i) for i in commitment_indexes)
 
-10. proof_with_add_zkp_info = CoreProofGen(PK,
-                        signature,
-                        generators.append(blind_generators),
-                        header,
-                        ph,
-                        proof_scalars,
-                        proof_disclosed_indexes,
-                        proof_commitment_indexes,
-                        api_id)
-11. return proof_with_add_zkp_info
+11. state_and_add_zkp_info_and_keybind_challenges = CoreProofGenInit(
+        PK,
+        signature,
+        generators.append(blind_generators).append(keybind_generators),
+        header,
+        ph,
+        proof_scalars,
+        proof_disclosed_indexes,
+        proof_commitment_indexes,
+        (PK_1, ..., PK_K),
+        api_id)
+12. return state_and_add_zkp_info_and_keybind_challenges
+```
+
+### Proof Generation Finalization
+
+TODO: Description
+
+```
+proof = BlindProofGenFinalize(state, keybind_signatures)
+
+Inputs:
+
+- state (REQUIRED), an octet string of the form of the first output of
+                    the BlindProofGenInit operation.
+- keybind_signatures (REQUIRED), a vector of octet strings.
+
+
+Parameters:
+
+- api_id, the octet string ciphersuite_id || "BLIND_H2G_HM2S_", where
+          ciphersuite_id is defined by the ciphersuite and
+          "BLIND_H2G_HM2S_"is an ASCII string composed of 15 bytes.
+
+Outputs:
+
+- proof, an octet string; or INVALID.
+
+Deserialization:
+
+1. state_res = octets_to_proof_gen_state(state)
+2. if state_res is INVALID, return INVALID
+3. (incomplete_proof, challenge, r_key) = state_res
+4. keybind_randomized_keys = incomplete_proof_octets_to_randomized_keys(incomplete_proof)
+5. if keybind_randomized_keys is INVALID, return INVALID
+6. K = length(keybind_randomized_keys)
+7. if length(keybind_signatures) != K, return INVALID
+
+Procedure:
+
+1. proof = incomplete_proof
+2. for i in (1..K)
+3.     PK~_i_octs = BBS.serialize((keybind_randomized_keys[i - 1]))
+4.     proof = proof || PK~_i_octs
+5. for i in (1..K)
+6.     proof = proof || Sig.AdaptSig(
+           keybind_signatures[i - 1], r_key[i - 1],
+           PK~_i_octs || BBS.serialize((challenge))) TODO: Should this be ph instead of challenge?
+7. return proof
 ```
 
 ### Proof Verification
@@ -615,33 +862,36 @@ Outputs:
 
 Deserialization:
 
-1. bbs_proof_len = OS2IP(proof[0..7])
-2. undisclosed_msgs_no = (bbs_proof_len
+1.  bbs_proof_len = OS2IP(proof[0..7])
+2.  N = OS2IP(proof[8..15])
+3.  K = OS2IP(proof[16..23])
+3.  undisclosed_msgs_no = (bbs_proof_len
                            - 3 * octet_point_length
                            - 4 * octet_scalar_length)
                            / octet_scalar_length
-3. proof_msgs_no = undisclosed_msgs_no + length(disclosed_messages)
-4. if proof_msgs_no == 0, return INVALID
-5. total_msgs_no = proof_msgs_no - 1
-6. if issuer_known_messages_no > total_msgs_no, return INVALID
-7. if length(message_disclosures) != total_msgs_no, return INVALID
-8. if the keys of message_disclosures are not exactly the integers
-   0..total_msgs_no - 1, return INVALID
-9. if any value in message_disclosures is not one of DISCLOSE, HIDE,
-   or COMMIT, return INVALID
+4.  proof_msgs_no = undisclosed_msgs_no + length(disclosed_messages)
+5.  if proof_msgs_no == 0, return INVALID
+6.  total_msgs_no = proof_msgs_no - 1 - K
+7.  if issuer_known_messages_no > total_msgs_no, return INVALID
+8.  if length(message_disclosures) != total_msgs_no, return INVALID
+9.  if the keys of message_disclosures are not exactly the integers
+    0..total_msgs_no - 1, return INVALID
+10. if any value in message_disclosures is not one of DISCLOSE, HIDE,
+    or COMMIT, return INVALID
 
-10. let disclosed_indexes be the integers i in 0..total_msgs_no - 1 so
-   that message_disclosures[i] = DISCLOSE, in
-   ascending order.
-11. let commitment_indexes be the integers i in 0..total_msgs_no - 1 so
-   that message_disclosures[i] = COMMIT, in
-   ascending order.
-12. if length(disclosed_indexes) != length(disclosed_messages),
+11. let disclosed_indexes be the integers i in 0..total_msgs_no - 1 so
+    that message_disclosures[i] = DISCLOSE, in
+    ascending order.
+12. let commitment_indexes be the integers i in 0..total_msgs_no - 1 so
+    that message_disclosures[i] = COMMIT, in
+    ascending order.
+13. if length(disclosed_indexes) != length(disclosed_messages),
     return INVALID
-13. let proof_index(i) be i if i < issuer_known_messages_no,
+14. if length(commitment_indexes) != N, return INVALID
+15. let proof_index(i) be i if i < issuer_known_messages_no,
     and i + 1 otherwise.
-14. proof_disclosed_indexes = (proof_index(i) for i in disclosed_indexes)
-15. proof_commitment_indexes = (proof_index(i) for i in commitment_indexes)
+16. proof_disclosed_indexes = (proof_index(i) for i in disclosed_indexes)
+17. proof_commitment_indexes = (proof_index(i) for i in commitment_indexes)
 
 
 Procedure:
@@ -651,48 +901,61 @@ Procedure:
 2. blind_generators = BBS.create_generators(
                                total_msgs_no - issuer_known_messages_no + 1,
                                "BLIND_" || api_id)
+3. keybind_generators = BBS.create_generators(K, "KEYBIND_" || api_id)
 
-3. message_scalars = BBS.messages_to_scalars(disclosed_messages, api_id)
+4. message_scalars = BBS.messages_to_scalars(disclosed_messages, api_id)
 
-4. result = CoreProofVerify(
+5. result = CoreProofVerify(
                         PK,
                         proof,
-                        generators.append(blind_generators),
+                        generators.append(blind_generators).append(keybind_generators),
                         header,
                         ph,
                         message_scalars,
                         proof_disclosed_indexes,
                         proof_commitment_indexes,
                         api_id)
-5. return result
+6. return result
 ```
 
 ## Core Operations
 
-### Core Commitment Computation
+### Core Commitment Initialization
 
 <!-- Once again this is only used for blind signing commitment. Should we rename? -->
 
 ```
-(commitment_with_proof, secret_prover_blind) = CoreCommit(blind_generators,
-                                              committed_message_scalars,
-                                              api_id)
+(commitment_state, secret_prover_blind, challenge)
+    = CoreCommitInit(blind_generators,
+                     committed_message_scalars,
+                     keybind_public_keys,
+                     api_id)
 
 Inputs:
 
 - blind_generators (REQUIRED), vector of pseudo-random points in G1.
 - committed_message_scalars (OPTIONAL), a vector of scalars. If not supplied,
                                  it defaults to the empty array ("()").
+- keybind_public_keys (OPTIONAL), a vector of points in G1. If not supplied,
+                                  it defaults to the empty array ("()").
 - api_id (OPTIONAL), an octet string. If not supplied it defaults to the
                      empty octet string ("").
 
+Outputs:
+
+- state, a point of G1, a scalar, a vector of scalars,
+         another scalar and a vector of points of G1 in that order.
+- secret_prover_blind, a scalar.
+- challenge, a scalar.
 
 Deserialization:
 
 1. M = length(committed_message_scalars)
-2. if length(blind_generators) != M + 1, return INVALID
-3. (Q_2, J_1, ..., J_M) = blind_generators
-4. (msg_1, ..., msg_M) = committed_message_scalars
+2. K = length(keybind_public_keys)
+3. if length(blind_generators) != M + K + 1, return INVALID
+4. (Q_2, J_1, ..., J_M, KJ_1, ..., KJ_K) = blind_generators
+5. (msg_1, ..., msg_M) = committed_message_scalars
+
 Procedure:
 
 1. (secret_prover_blind, s~, m~_1, ..., m~_M)
@@ -701,14 +964,43 @@ Procedure:
 3. Cbar = J_1 * m~_1 + ... + J_M * m~_M + Q_2 * s~
 
 4. challenge = calculate_blind_challenge(C, Cbar, blind_generators,
-                                                                 api_id)
+                                         keybind_public_keys, api_id)
 
 5. s^ = s~ + secret_prover_blind * challenge
 6. for i in (1, 2, ..., M): m^_i = m~_i + msg_i * challenge
 
-7. proof = (s^, (m^_1, ..., m^_M), challenge)
-8. commitment_with_proof = commitment_with_proof_to_octets(C, proof)
-9. return (commitment_with_proof, secret_prover_blind)
+7. state = (C, s^, (m^_1, ..., m^_M), challenge, keybind_public_keys)
+8. return (state, secret_prover_blind, challenge)
+```
+
+### Core Commitment Finalization
+
+```
+((C, keybind_public_keys), (s^, m^, challenge, keybind_signatures))
+    = CoreCommitFinalize(state, keybind_signatures)
+
+Inputs:
+
+- state (REQUIRED), a point of G1, a scalar, a vector of scalars,
+                    another scalar and a vector of points of G1 in that order.
+- keybind_signatures (OPTIONAL), a vector of octet strings. If not supplied,
+                                 it defaults to the empty array ("()").
+
+Outputs:
+
+- C, a point in G1.
+- keybind_public_keys, a vector of points in G1.
+- s^, a scalar.
+- m^, a vector of scalars.
+- challenge, a scalar.
+- keybind_signatures, a vector of octet strings.
+
+Procedure:
+
+1. (C, s^, m^, challenge, keybind_public_keys) = state
+2. K = length(keybind_public_keys)
+3. if length(keybind_signatures) != K, return INVALID
+4. return ((C, keybind_public_keys), (s^, m^, challenge, keybind_signatures))
 ```
 
 ### Core Commitment Verification
@@ -716,12 +1008,13 @@ Procedure:
 This operation is used by the Signer to verify the correctness of a `commitment_proof` for a supplied `commitment`, over a list of points of G1 called the `blind_generators`, used to compute that commitment.
 
 ```
-result = CoreCommitVerify(commitment, commitment_proof,
+result = CoreCommitVerify(commitment, keybind_public_keys, commitment_proof,
                                                blind_generators, api_id)
 
 Inputs:
 
 - commitment (REQUIRED), a commitment (see (#terminology)).
+- keybind_public_keys (REQUIRED), a vector of points in G1.
 - commitment_proof (REQUIRED), a commitment_proof (see (#terminology)).
 - blind_generators (REQUIRED), vector of pseudo-random points in G1.
 - api_id (OPTIONAL), octet string. If not supplied it defaults to the
@@ -734,21 +1027,28 @@ Outputs:
 
 Deserialization:
 
-1. (s^, commitments, cp) = commitment_proof
+1. (s^, commitments, cp, keybind_signatures) = commitment_proof
 
 2. M = length(commitments)
-3. (m^_1, ..., m^_M) = commitments
+3. K = length(keybind_public_keys)
+4. (m^_1, ..., m^_M) = commitments
 
-4. if length(blind_generators) != M + 1, return INVALID
-5. (Q_2, J_1, ..., J_M) = blind_generators
+5. if length(blind_generators) != M + K + 1, return INVALID
+7. if length(keybind_signatures) != K, return INVALID
+
+8. (Q_2, J_1, ..., J_M, KJ_1, ..., KJ_K) = blind_generators
 
 Procedure:
 
 1. Cbar = J_1 * m^_1 + ... + J_M * m^_M + Q_2 * s^ + commitment * (-cp)
 2. cv = calculate_blind_challenge(commitment, Cbar, blind_generators,
-                                                                 api_id)
+                                  keybind_public_keys, api_id)
 3. if cv != cp, return INVALID
-4. return VALID
+4. for i in (1..K)
+7.     if Sig.Verify(KJ_i, keybind_public_keys[i-1],
+                     keybind_signatures[i-1], BBS.serialize((cp))
+                     ) is INVALID, return INVALID
+8. return VALID
 ```
 
 ### Finalize Blind Sign
@@ -788,7 +1088,66 @@ Procedure:
 5. return BBS.signature_to_octets((A, e))
 ```
 
-### Core Proof Generation
+### Core Blind Signature Verification {#CoreVerify}
+
+This operation validates a blind BBS signature (`signature`), given the Signer's public key (`PK`), a header (`header`), a set of messages (`messages`), including first the messages chosen by the Issuer and then the ones chosen (and committed to) by the Prover and if used, the `secret_prover_blind` as returned by the `Commit` operation ((#commitment-computation)).
+
+TODO: Update description
+
+```
+result = CoreVerify(PK, signature, generators,
+                    header, messages, keybind_public_keys, api_id)
+
+Inputs:
+
+- PK (REQUIRED), an octet string of the form outputted by the SkToPk
+                 operation.
+- signature (REQUIRED), an octet string of the form outputted by the
+                        Sign operation.
+- generators (REQUIRED), vector of pseudo-random points in G1.
+- header (OPTIONAL), an octet string containing context and application
+                     specific information. If not supplied, it defaults
+                     to the empty octet string ("").
+- messages (OPTIONAL), a vector of scalars representing the messages.
+                       If not supplied, it defaults to the empty
+                       array ("()").
+- keybind_public_keys (OPTIONAL), a vector of points of G1.
+                       If not supplied, it defaults to the empty
+                       array ("()").
+- api_id (OPTIONAL), an octet string. If not supplied it defaults to the
+                     empty octet string ("").
+
+Parameters:
+
+- P1, fixed point of G1, defined by the ciphersuite.
+
+Outputs:
+
+- result, either VALID or INVALID.
+
+Deserialization:
+
+1.  signature_result = BBS.octets_to_signature(signature)
+2.  if signature_result is INVALID, return INVALID
+3.  (A, e) = signature_result
+4.  W = BBS.octets_to_pubkey(PK)
+5.  if W is INVALID, return INVALID
+6.  L = length(messages)
+7.  K = length(keybind_public_keys)
+8.  if length(generators) != L + K + 1, return INVALID
+9.  (msg_1, ..., msg_L) = messages
+10. (PK_1, ..., PK_K) = keybind_public_keys
+11. (Q_1, H_1, ..., H_L, KJ_1, ..., KJ_K) = generators
+
+Procedure:
+
+1. domain = calculate_domain(PK, Q_1, (H_1, ..., H_L, KJ_1, ..., KJ_K), header, api_id)
+2. B = P1 + Q_1 * domain + H_1 * msg_1 + ... + H_L * msg_L + PK_1 + ... + PK_K
+3. if h(A, W) * h(A * e - B, BP2) != Identity_GT, return INVALID
+4. return VALID
+```
+
+### Core Proof Generation Initialization
 
 The Proof Generation with extension, combines the BBS Proof Generation operations (i.e., `BBS.ProofInit` and `BBS.ProofFinalize`) with a proof of correctness of commitments over some of the signed messages. The commitments proof of correctness will similarly constitute of a initialization and finalization phase. The two proof protocols will use a common challenge, returned by the `ProofChallengeCalculate` operation described in (#proof-challenge-calculation). The result of the commitments proof of correctness initialization process will be an object of the following form
 
@@ -804,12 +1163,11 @@ CommitmentInitRes = {
 
 Following, we describe the Proof Generation Procedure.
 
-
 ```
-[proof, add_zkp_info] = CoreProofGen(PK, signature, generators,
-                                     header, ph, messages,
-                                     disclosed_indexes,
-                                     commitment_indexes, api_id)
+[proof, add_zkp_info] = CoreProofGenInit(
+    PK, signature, generators, header, ph,
+    messages, disclosed_indexes, commitment_indexes,
+    keybind_public_keys, api_id)
 
 Inputs:
 
@@ -835,6 +1193,9 @@ Inputs:
                                  ascending order. Indexes of committed
                                  messages. If not supplied, it defaults
                                  to the empty array ("()").
+- keybind_public_keys (OPTIONAL), a vector of points of G1.
+                       If not supplied, it defaults to the empty
+                       array ("()").
 - api_id (OPTIONAL), an octet string. If not supplied it defaults to the
                      empty octet string ("").
 
@@ -845,10 +1206,11 @@ Parameters:
 
 Outputs:
 
-- proof, an octet string; or INVALID.
+- state, an octet string; or INVALID.
 - add_zkp_info, a structure containing an array of committed message scalars
                 used in committed disclosure, and the array of random scalars
                 used to create the respective commitments.
+- keybind_challenges, a vector of octet strings
 
 Deserialization:
 
@@ -866,71 +1228,86 @@ Deserialization:
 8.  N = length(commitment_indexes)
 9.  R = length(disclosed_indexes)
 10. U = L - R
-11. (i1, ..., iR) = disclosed_indexes
-12. disclosed_messages = (messages[i1], ..., messages[iR])
-13. undisclosed_indexes = (0, 1, ..., L - 1) \ disclosed_indexes
-14. (j1, ..., jU) = undisclosed_indexes
-15. undisclosed_messages = (messages[j1], ..., messages[jU])
+11. K = length(keybind_public_keys)
+12. (i1, ..., iR) = disclosed_indexes
+13. disclosed_messages = (messages[i1], ..., messages[iR])
+14. undisclosed_indexes = (0, 1, ..., L - 1) \ disclosed_indexes
+15. (j1, ..., jU) = undisclosed_indexes
+16. undisclosed_messages = (messages[j1], ..., messages[jU])
+17. (PK_1, ..., PK_K) = keybind_public_keys
 
 Procedure:
 
-1.  init_random_scalars = BBS.calculate_random_scalars(5+U)
-2.  (r1, r2, e~, r1~, r3~, m~_j1, ..., m~_jU) =
-                                         init_random_scalars
+1.  init_random_scalars = BBS.calculate_random_scalars(5 + U + 2*K)
+2.  (r1, r2, e~, r1~, r3~, m~_j1, ..., m~_jU,
+        r_key~_1, ..., r_key~_K, r_key_1, ..., r_key_K) = init_random_scalars
 3.  init_res = BBS.ProofInit(PK,
                              signature_result,
                              generators,
-                             init_random_scalars,
+                             (r1, r2, e~, r1~, r3~, m~_j1, ..., m~_jU, r_key~_1, ..., r_key~_K),
                              header,
-                             messages,
-                             undisclosed_indexes,
+                             messages.append((0 for i in (1..K))),
+                             undisclosed_indexes.append((L + i for i in (0..(K-1)))),
                              api_id)
 4.  if init_res is INVALID, return INVALID
+5.  (Abar, Bbar_init, D_init, T1_init, T2_init, domain) = init_res
+6.  D_add = r2 * (PK_1 + ... + PK_K)
+7.  D = D_init + D_add
+8.  Bbar = Bbar_init + D_add * r1
+9.  T1 = T1_init + D_add * r1~
+10. T2 = T2_init + D_add * r3~
+11. for i in (1..K)
+12.     PK~_i = PK_i + generators[L + 1 + i - 1] * r_key_i
 
 
 // Calculate the commitments and initiate the correctness proof
-5.  (s_1, ..., s_N, s~_1, ..., s~_N) = BBS.calculate_random_scalars(2*N)
+11. (s_1, ..., s_N, s~_1, ..., s~_N) = BBS.calculate_random_scalars(2*N)
 
-6.  for i in (1, 2, ..., N):
-7.      idx = commitment_indexes[i]
-8.      C_i = Y_0 * s_i + Y_1 * messages[idx]
-9.      let k be the integer such that j_k == idx
-10.     C~_i = Y_0 * s~_i + Y_1 * m~_k
+12. for i in (1, 2, ..., N):
+13.     idx = commitment_indexes[i - 1]
+14.     C_i = Y_0 * s_i + Y_1 * messages[idx]
+15.     let k be the integer such that j_k == idx
+16.     C~_i = Y_0 * s~_i + Y_1 * m~_k
 
-11. commitment_init_res = {commitments: (C_1, ..., C_N),
+17. commitment_init_res = {commitments: (C_1, ..., C_N),
                            commitments_proofs: (C~_1, ...,C~_N),
                            commitment_indexes: commitment_indexes}
 
-12. challenge = ProofChallengeCalculate(init_res, commitment_init_res,
+18. challenge = ProofChallengeCalculate((Abar, Bbar, D, T1, T2, domain),
+                                        commitment_init_res,
+                                        (PK~_1, ..., PK~_K),
                                         disclosed_messages, disclosed_indexes,
                                         ph, api_id)
-13. if challenge is INVALID, return INVALID
+19. if challenge is INVALID, return INVALID
 
-14. bbs_proof = BBS.ProofFinalize(init_res,
+20. bbs_proof = BBS.ProofFinalize((Abar, Bbar, D, T1, T2, domain),
                                   challenge,
                                   e,
-                                  init_random_scalars,
-                                  undisclosed_messages)
+                                  (r1, r2, e~, r1~, r3~, m~_j1, ..., m~_jU, r_key~_1, ..., r_key~_K),
+                                  undisclosed_messages.append((-r_key_1, ..., -r_key_K)))
 
 // Finalize the commitment correctness proof
-15. for i in (1, 2, ..., N): s^_i =  s~_i + challenge * s_i
-16. commitments_proof = ((C_1, ..., C_N), (s^_1, ..., s^_N))
+21. for i in (1, 2, ..., N): s^_i =  s~_i + challenge * s_i
+22. commitments_proof = ((C_1, ..., C_N), (s^_1, ..., s^_N))
 
-17. proof = proof_to_octets(length(bbs_proof), bbs_proof,
-                           N, commitments_proof)
-18. add_zkp_info = {committed_message_scalars:
+23. state = proof_gen_state_to_octets(bbs_proof, challenge,
+                                      N, commitments_proof,
+                                      (PK~_1, ..., PK~_K),
+                                      (r_key_1, ..., r_key_K))
+24. for i in (1..K)
+25.     c_r_key_i = serialize((PK~_i, challenge))  TODO: Should this be ph instead of challenge?
+26. add_zkp_info = {committed_message_scalars:
                        (messages[commitment_indexes[1]], ...,
                         messages[commitment_indexes[N]]),
                     commitment_rands: (s_1, ..., s_N)}
-19. return [proof, add_zkp_info]
+27. return [state, add_zkp_info, (c_r_key_1, ..., c_r_key_K)]
 ```
 
 ### Core Proof Verification
 
 ```
 result = CoreProofVerify(PK, proof, generators, header, ph,
-                         disclosed_messages, disclosed_indexes,
-                         commitment_indexes, api_id)
+    disclosed_messages, disclosed_indexes, commitment_indexes, api_id)
 
 Inputs:
 
@@ -970,64 +1347,76 @@ Outputs:
 
 Deserialization:
 
-1.  W = octets_to_pubkey(PK)
+1.  W = BBS.octets_to_pubkey(PK)
 2.  if W is INVALID, return INVALID
 
 3.  proof_res = octets_to_proof(proof)
 4.  if proof_res is INVALID, return INVALID
-5.  (bbs_proof_res, commitments_proof_res) = proof_res
+5.  (bbs_proof_res, commitments_proof_res, (keybind_randomized_keys, keybind_signatures)) = proof_res
 
 6.  (Abar, Bbar, D, e^, r1^, r3^, hats, cp) = bbs_proof_res
 7.  (commitments, commitments_proof) = commitments_proof_res
 
 8.  N = length(commitments)
-9.  if length(commitments_proof) != N, return INVALID
-10. if length(commitment_indexes) != N, return INVALID
-11. U = length(hats)
-12. R = length(disclosed_indexes)
-13. if length(disclosed_messages) != R, return INVALID
-14. L = R + U
+9.  K = length(keybind_randomized_keys)
+10. if length(commitments_proof) != N, return INVALID
+11. if length(commitment_indexes) != N, return INVALID
+12. U = length(hats)
+13. R = length(disclosed_indexes)
+14. if length(disclosed_messages) != R, return INVALID
+15. L = R + U
+16. if length(generators) != L + 1, return INVALID
+17. if length(keybind_signatures) != K, return INVALID
 
-15. if commitment_indexes is not a strictly ascending list of integers
+18. if commitment_indexes is not a strictly ascending list of integers
     in 0..L - 1, return INVALID
 
-16. if disclosed_indexes is not a strictly ascending list of integers
+19. if disclosed_indexes is not a strictly ascending list of integers
     in 0..L - 1, return INVALID
 
-17. if disclosed_indexes and commitment_indexes are not disjoint,
+20. if disclosed_indexes and commitment_indexes are not disjoint,
     return INVALID
 
-18. undisclosed_indexes = (0, 1, ..., L - 1) \ disclosed_indexes
-19. (j1, ..., jU) = undisclosed_indexes
-20. (m^_j1, ..., m^_jU) = hats
-21. (C_1, ... C_N) = commitments
-22. (s^_1, ..., s^_N) = commitments_proof
+21. undisclosed_indexes = (0, 1, ..., L - 1) \ disclosed_indexes
+22. (j1, ..., jU) = undisclosed_indexes
+23. (m^_j1, ..., m^_jU) = hats
+24. (C_1, ... C_N) = commitments
+25. (s^_1, ..., s^_N) = commitments_proof
+26. (PK~_1, ..., PK~_K) = keybind_randomized_keys
 
 Procedure:
 
 1.  init_res = BBS.ProofVerifyInit(PK, bbs_proof_res, generators, header,
-                                                   disclosed_messages,
-                                                   disclosed_indexes,
-                                                   api_id)
+        disclosed_messages, disclosed_indexes, api_id)
 2.  if init_res is INVALID, return INVALID
+3.  (Abar, Bbar, D, T1, T2_init, domain) = init_res
+5.  T2 = T2_init + cp * (PK~_1 + ... + PK~_K)
 
-3.  for i in (1, 2, ..., N):
-4.      idx = commitment_indexes[i]
-5.      let k be the integer such that j_k == idx
-6.      C^_i = Y_0 * s^_i + Y_1 * m^_k - C_i * cp
+5.  for i in (1, 2, ..., N):
+6.      idx = commitment_indexes[i - 1]
+7.      let k be the integer such that j_k == idx
+8.      C^_i = Y_0 * s^_i + Y_1 * m^_k - C_i * cp
 
-7.  commitment_init_res = {commitments: (C_1, ..., C_N),
+9.  commitment_init_res = {commitments: (C_1, ..., C_N),
                            commitments_proofs: (C^_1, ...,C^_N),
                            commitment_indexes: commitment_indexes}
 
-8.  challenge = ProofChallengeCalculate(init_res, commitment_init_res,
+10. challenge = ProofChallengeCalculate((Abar, Bbar, D, T1, T2, domain),
+                                        commitment_init_res,
+                                        keybind_randomized_keys,
                                         disclosed_messages, disclosed_indexes,
                                         ph, api_id)
-9.  if challenge is INVALID, return INVALID
+11. if challenge is INVALID, return INVALID
 
-10. if cp != challenge, return INVALID
-11. if e(Abar, W) * e(Bbar, -BP2) != Identity_GT, return INVALID
-12. return VALID
+12. if cp != challenge, return INVALID
+13. for i in (0..(K-1))
+14.     if Sig.Verify(generators[L + 1 - K + i],
+                      keybind_randomized_keys[i],
+                      keybind_signatures[i],
+                      BBS.serialize((keybind_randomized_keys[i], challenge)) TODO: Should this be ph instead of challenge?
+            ) is INVALID, return INVALID
+15. if e(Abar, W) * e(Bbar, -BP2) != Identity_GT, return INVALID
+16. return VALID
 ```
 
 # Utilities
@@ -1088,7 +1477,8 @@ Procedure:
 ## Blind Challenge Calculation
 
 ```
-challenge = calculate_blind_challenge(C, Cbar, generators, api_id)
+challenge = calculate_blind_challenge(C, Cbar, generators,
+                                      keybind_public_keys, api_id)
 
 Inputs:
 
@@ -1096,6 +1486,7 @@ Inputs:
 - Cbar (REQUIRED), a point of G1.
 - generators (REQUIRED), an array of points from G1, of length at
                          least 1.
+- keybind_public_keys (REQUIRED), an array of points from G1.
 - api_id (OPTIONAL), octet string. If not supplied it defaults to the
                      empty octet string ("").
 
@@ -1108,12 +1499,13 @@ Definition:
 Deserialization:
 
 1. if length(generators) == 0, return INVALID
-2. M = length(generators) - 1
+2. K = length(keybind_public_keys)
+3. M = length(generators) - 1 - K
 
 Procedure:
 
-1. c_arr = (M)
-2. c_arr.append(generators)
+1. c_arr = (M, K)
+2. c_arr = c_arr.append(generators).append(keybind_public_keys)
 3. c_octs = BBS.serialize(c_arr.append(C, Cbar))
 4. return BBS.hash_to_scalar(c_octs, blind_challenge_dst)
 ```
@@ -1122,6 +1514,7 @@ Procedure:
 
 ```
 challenge = ProofChallengeCalculate(init_res, commitment_init_res,
+                                    keybind_randomized_keys,
                                     disclosed_messages, disclosed_indexes,
                                     ph, api_id)
 
@@ -1133,6 +1526,9 @@ Inputs:
                                  returned after initializing the commitments
                                  proof of correctness generation or
                                  verification.
+- keybind_randomized_keys (OPTIONAL), a vector of points of G1. If not
+                                      supplied, it defaults to the empty
+                                      array ("()").
 - disclosed_messages (OPTIONAL), a vector of scalars representing the
                                  messages. If not supplied, it defaults
                                  to the empty array ("()").
@@ -1166,7 +1562,7 @@ Deserialization:
 
 2.  R = length(disclosed_indexes)
 3.  (i1, ..., iR) = disclosed_indexes
-4. if length(disclosed_messages) != R, return INVALID
+4.  if length(disclosed_messages) != R, return INVALID
 5.  (msg_i1, ..., msg_iR) = disclosed_messages
 
 6.  N = length(commitment_init_res.commitments)
@@ -1175,6 +1571,7 @@ Deserialization:
 9.  (C_1, ..., C_N) = commitment_init_res.commitments
 10. (C~_1, ...,C~_N) = commitment_init_res.commitments_proofs
 11. (i_1, ..., i_N) = commitment_init_res.commitment_indexes
+12. K = length(keybind_randomized_keys)
 
 ABORT if:
 
@@ -1189,12 +1586,100 @@ Procedure:
 
 3. commitment_arr = (N, i_1, C_1, C~_1, ..., i_N, C_N, C~_N)
 4. c_octs = c_octs || BBS.serialize(commitment_arr)
+5. c_octs = c_octs || BBS.serialize((K).append(keybind_randomized_keys))
 
-5. c_octs = c_octs || I2OSP(length(ph), 8) || ph
-6. return BBS.hash_to_scalar(c_octs, hash_to_scalar_dst)
+6. c_octs = c_octs || I2OSP(length(ph), 8) || ph
+7. return BBS.hash_to_scalar(c_octs, hash_to_scalar_dst)
 ```
 
 ## Serialize
+
+
+
+### Commitment State to Octets
+
+```
+state_octets = commitment_state_to_octets(state)
+
+Inputs:
+- state (REQUIRED), a point of G1, a scalar, a vector of scalars,
+                    a scalar and a vector of points of G1 in that order.
+
+Outputs:
+
+- state_octets, an octet string or INVALID.
+
+Deserialization:
+
+1. (C, s^, m^, challenge, keybind_public_keys) = state
+2. M = length(m^)
+3. K = length(keybind_public_keys)
+
+Procedure:
+
+1. return BBS.serialize(
+       (M, K, C, s^)
+       .append(m^).append((challenge))
+       .append(keybind_public_keys))
+```
+
+### Octets to Commitment State
+
+```
+commitment = octets_to_commitment_state(state_octs)
+
+Inputs:
+
+- state_octs (REQUIRED), an octet string in the form outputted from
+                         the commitment_state_to_octets operation.
+
+Parameters:
+
+- (octet_point_length, octet_scalar_length), defined by the ciphersuite.
+
+Outputs:
+
+- state, a state in the form (C, s^, m^, challenge, keybind_public_keys)
+         where C is a point of G1, s^ and challenge are
+         scalars, m^ is a vector of scalars and keybind_public_keys is a
+         vector of points of G1.
+
+Procedure:
+
+1.  if length(state_octs) < 16, return INVALID
+2.  M = OS2IP(state_octs[0..7]
+3.  K = OS2IP(state_octs[8..15]
+4.  if length(state_octs) != 16
+        + (1 + K) * octet_point_length
+        + (2 + M) * octet_scalar_length,
+        return INVALID
+
+5.  sidx = 16
+6.  eidx = sidx + octet_point_length - 1
+7.  C_octets = state_octs[sidx..eidx]
+8.  C = BBS.octets_to_point_E1(C_octets)
+9.  if C is INVALID, return INVALID
+10. if C == Identity_G1, return INVALID
+11. sidx = eidx + 1
+
+12. for j in (0..(M + 1))
+13.     eidx = sidx + octet_scalar_length - 1
+14.     s_j = OS2IP(state_octs[sidx..eidx])
+15.     if s_j = 0 or if s_j >= r, return INVALID
+16.     sidx = eidx + 1
+
+17. for i in (1..K)
+18.     eidx = sidx + octet_point_length - 1
+19.     PK_i_octs = state_octs[sidx..eidx]
+20.     PK_i = Bbs.octets_to_point_E1(PK_i_octs)
+21.     if PK_i is INVALID, return INVALID
+22.     if PK_i == Identity_G1, return INVALID
+23.     sidx = eidx + 1
+
+24. m^ = (s_1, ..., s_M)
+25. challenge = s_{M+1}
+26. return (C, s_0, m^, challenge, (PK_1, ..., PK_K))
+```
 
 ### Commitment with Proof to Octets
 
@@ -1203,22 +1688,30 @@ commitment_octets = commitment_with_proof_to_octets(commitment, proof)
 
 Inputs:
 
-- commitment (REQUIRED), a point of G1.
+- commitment (REQUIRED), a point of G1 and a possibly empty vector of
+                         points of G1.
 - proof (REQUIRED), a vector comprising of a scalar, a possibly empty
-                    vector of scalars and another scalar in that order.
+                    vector of scalars, another scalar and another
+                    possibly empty vector of octet strings in that order.
 
 Outputs:
 
 - commitment_octets, an octet string or INVALID.
 
+Deserialization:
+
+1. (C, keybind_public_keys) = commitment
+2. (s^, m^, challenge, keybind_signatures) = proof
+3. M = length(m^)
+4. K = length(keybind_public_keys)
+5. if length(keybind_signatures) != K, return INVALID
+
 Procedure:
 
-1. commitment_octs = BBS.serialize((commitment))
-2. if commitment_octs is INVALID, return INVALID
-3. (s^, (m^_1, ..., m^_M), challenge) = proof
-4. proof_octs = BBS.serialize((s^, m^_1, ..., m^_M, challenge))
-5. if proof_octs is INVALID, return INVALID
-6. return commitment_octs || proof_octs
+1. return BBS.serialize(
+       (M, K, C).append(keybind_public_keys)
+       .append((s^).append(m^).append((challenge)))
+       || keybind_signatures[0] || ... || keybind_signatures[K - 1]
 ```
 
 ### Octets to Commitment with Proof
@@ -1237,60 +1730,141 @@ Parameters:
 
 Outputs:
 
-- commitment, a commitment in the form (C, proof), where C a point of G1
-              and a proof vector comprising of a scalar, a possibly
-              empty vector of scalars and another scalar in that order.
+- commitment, a commitment in the form ((C, keybind_public_keys), proof),
+              where C is a point of G1, keybind_public_keys is a vector
+              of points of G1 and proof is a vector comprised of a scalar,
+              a possibly empty vector of scalars, another scalar and a
+              possibly empty vector of octet strings in that order.
 
 Procedure:
 
-1.  commitment_len_floor = octet_point_length + 2 * octet_scalar_length
-2.  if length(commitment_octs) < commitment_len_floor, return INVALID
+1.  if length(commitment_octs) < 16, return INVALID
+2.  M = OS2IP(commitment_octs[0..7]
+3.  K = OS2IP(commitment_octs[8..15]
+4.  if length(commitment_octs) != 16
+        + (1 + K) * octet_point_length
+        + (2 + M) * octet_scalar_length,
+        + K * Sig.signature_length,
+        return INVALID
 
-3.  C_octets = commitment_octs[0..(octet_point_length - 1)]
-4.  C = octets_to_point_E1(C_octets)
-5.  if C is INVALID, return INVALID
-6.  if C == Identity_G1, return INVALID
+5.  sidx = 16
+6.  C_octets = commitment_octs[sidx..(sidx + octet_point_length - 1)]
+7.  C = BBS.octets_to_point_E1(C_octets)
+8.  if C is INVALID, return INVALID
+9.  if C == Identity_G1, return INVALID
+10. sidx = sidx + octet_point_length
 
-7.  j = 0
-8.  index = octet_point_length
-9.  while index < length(commitment_octs):
-10.     end_index = index + octet_scalar_length - 1
-11.     s_j = OS2IP(commitment_octs[index..end_index])
-12.     if s_j = 0 or if s_j >= r, return INVALID
-13.     index += octet_scalar_length
-14.     j += 1
+11. for i in (1..K)
+12.     eidx = sidx + octet_point_length - 1
+13.     PK_i_octs = commitment_octs[sidx..eidx]
+14.     PK_i = BBS.octets_to_point_E1(PK_i_octs)
+15.     if PK_i is INVALID, return INVALID
+16.     if PK_i == Identity_G1, return INVALID
+17.     sidx = eidx + 1
 
-15. if index != length(commitment_octs), return INVALID
-16. if j < 2, return INVALID
-17. msg_commitments = ()
-18. if j >= 3, set msg_commitments = (s_1, ..., s_(j-2))
-19. return (C, (s_0, msg_commitments, s_(j-1)))
+17. for j in (0..M + 1)
+18.     eidx = sidx + octet_scalar_length - 1
+19.     s_j = OS2IP(commitment_octs[sidx..eidx])
+20.     if s_j = 0 or if s_j >= r, return INVALID
+21.     sidx = eidx + 1
+
+22. for i in (1..K)
+23.     eidx = sidx + Sig.signature_length
+24.     keybind_signatures[i-1] = commitment_octs[sidx..eidx]
+25.     sidx = eidx + 1
+
+26. msg_commitments = (s_1, ..., s_M)
+27. challenge = s_(M + 1)
+28. return ((C, (PK_1, ..., PK_K)),
+            (s_0, msg_commitments, challenge, keybind_signatures))
 ```
 
-### Proof to Octets
+### Proof Generation State to Octets
 
 ```
-proof_octets = proof_to_octets(bbs_proof_len, bbs_proof_octs,
-                               commitments_count, commitments_proof)
+state_octets = proof_gen_state_to_octets(
+                   bbs_proof, challenge,
+                   commitments_proof,
+                   keybind_randomized_keys, keybind_randomizers)
 
 Inputs:
 
-- bbs_proof_len (REQUIRED), a non negative integer.
-- bbs_proof_octs (REQUIRED), an octet string.
-- commitments_count (REQUIRED), a non negative integer.
-- commitments_proof (REQUIRED), a tuple with two arrays, the first with
-                                points in G1 and the second with Scalars
+- bbs_proof (REQUIRED), an octet string.
+- challenge (REQUIRED), a scalar.
+- commitments_proof (REQUIRED), a tuple of a vector of points of G1
+                                and a vector of scalars.
+- keybind_randomized_keys (REQUIRED), a vector of points of G1.
+- keybind_randomizers (REQUIRED), a vector of scalars.
 
 Outputs:
 
-- proof_octets, an octet string.
+- state_octets, an octet string.
 
 Procedure:
 
-1. oct = I2OSP(bbs_proof_len, 8) || bbs_proof_octs ||
-         I2OSP(commitments_count, 8) || BBS.serialize(commitments_proof)
-2. return oct
+1. (commitments, commitment_proofs) = commitments_proof
+2. N = length(commitments)
+3. if length(commitment_proofs) != N, return INVALID
+4. K = length(keybind_randomized_keys)
+5. if length(keybind_randomizers) != K, return INVALID
 
+6. oct = BBS.serialize((length(bbs_proof), N, K))
+       || bbs_proof
+       || BBS.serialize(commitments.append(commitment_proofs)
+                        .append(challenge)
+                        .append(keybind_randomized_keys)
+                        .append(keybind_randomizers))
+7. return oct
+
+```
+
+### Octets to Proof Generation State
+
+```
+state = octets_to_proof_gen_state(state_octets)
+
+Inputs:
+
+- state_octets, an octet string.
+
+Outputs:
+
+- incomplete_proof (REQUIRED), an octet string.
+- challenge (REQUIRED), a scalar.
+- keybind_randomized_keys (REQUIRED), a vector of points of G1.
+- keybind_randomizers (REQUIRED), a vector of scalars.
+
+Procedure:
+
+1.  if length(state_octets) < 24, return INVALID
+2.  bbs_proof_len = OS2IP(state_octets[0..7])
+3.  K = OS2IP(state_octets[8..15])
+4.  N = OS2IP(state_octets[16..23])
+5.  if length(state_octets) != 24
+        + bbs_proof_len + (N + K) * octet_point_length
+        + (1 + N + K) * octet_scalar_length,
+        return INVALID
+
+6.  sidx = length(state_octets) - K * (octet_point_length + octet_scalar_length)
+7.  incomplete_proof = state_octets[0..(sidx - octet_scalar_length - 1)]
+8.  challenge = OS2IP(state_octets[(sidx - octet_scalar_length)..(sidx - 1)])
+9.  if challenge = 0 or if challenge >= r, return INVALID
+
+10. for i in (1..K)
+11.     eidx = sidx + octet_point_length - 1
+12.     PK~_i = BBS.octets_to_point_E1(state_octets[sidx..eidx])
+13.     if PK~_i is INVALID, return INVALID
+14.     if PK~_i == Identity_G1, return INVALID
+15.     sidx = eidx + 1
+
+16  for i in (1..K)
+17.     eidx = sidx + octet_scalar_length - 1
+18.     r_key_i = OS2IP(state_octets[sidx..eidx])
+19.     if r_key_i = 0 or if r_key_i >= r, return INVALID
+20.     sidx = eidx + 1
+
+21. return (incomplete_proof, challenge,
+            (PK~_1, ..., PK~_K), (r_key_1, ..., r_key_K))
 ```
 
 ### Octets to Proof
@@ -1299,12 +1873,14 @@ The `octets_to_proof` procedure, on input an octet string will return a BBS proo
 
 1. A BBS Proof
 2. A tuple with two arrays. One array of points in G1, corresponding to the message commitments and one array with scalars, corresponding to the proof of correctness of the previous commitments.
+3. A tuple with two arrays. One array of points in G1, containing randomized key binding public keys,
+  and one array of octet strings, containing signatures by the key binding keys.
 
 ```
 proof = octets_to_proof(proof_octets)
 
 - proof_octets (REQUIRED), an octet string of the form outputted from
-                           the proof_to_octets operation.
+                           the BlindProofGenFinalize operation.
 
 Parameters:
 
@@ -1331,38 +1907,60 @@ Procedure:
 4.  bbs_proof_len = OS2IP(proof_octets[sidx, ..., eidx])
 
 5.  sidx = eidx + 1
-6.  eidx = sidx + bbs_proof_len
+6.  eidx = sidx + int_octet_length
 7.  if length(proof_octets) < eidx, return INVALID
-8.  bbs_proof_octs = proof_octets[sidx, ..., eidx]
-9.  bbs_proof = BBS.octets_to_proof(bbs_proof_octs)
-10. if bbs_proof is INVALID, return INVALID
+8.  N = OS2IP(proof_octets[sidx, ..., eidx]) // commitments count
+
+9.  sidx = eidx + 1
+10. eidx = sidx + int_octet_length - 1
+11. if length(proof_octets) < eidx, return INVALID
+12. K = OS2IP(proof_octets[sidx, ..., eidx])
+
+13. expect_len = 3 * int_octet_length + bbs_proof_len,
+                 + N * (octet_point_length + octet_scalar_length)
+                 + K * (octet_point_length + Sig.signature_length)
+14. if length(proof_octets) != expect_len, return INVALID
+
+
+15. sidx = eidx + 1
+16. eidx = sidx + bbs_proof_len - 1
+17. if length(proof_octets) < eidx, return INVALID
+18. bbs_proof_octs = proof_octets[sidx, ..., eidx]
+19. bbs_proof = BBS.octets_to_proof(bbs_proof_octs)
+20. if bbs_proof is INVALID, return INVALID
 
 // Deserialize commitments_proof
-11. sidx = eidx + 1
-12. eidx = sidx + int_octet_length
-13. if length(proof_octets) < eidx, return INVALID
-14. N = OS2IP(proof_octets[sidx, ..., eidx]) // commitments count
+21. for i in (1..N)
+22.     sidx = eidx + 1
+23.     eidx = sidx + octet_point_length - 1
+24.     C_i = BBS.octets_to_point_E1(proof_octets[sidx, ..., eidx])
+25.     if C_i is INVALID or Identity_G1, return INVALID
+26.     if subgroup_check_G1(C_i) returns INVALID, return INVALID
 
-15. len_floor = eidx + N * (octet_point_length + octet_scalar_length)
-16. if length(proof_octets) < len_floor, return INVALID
+27. for i in (1..N)
+28.     sidx = eidx + 1
+29.     eidx = sidx + octet_scalar_length - 1
+30.     s_i = OS2IP(proof_octets[sidx, ..., eidx])
+31.     if s_i = 0 or if s_i >= r, return INVALID
 
-17. for i in (1..N)
-18.     sidx = eidx + 1
-19.     eidx = sidx + octet_point_length
-20.     C_i = BBS.octets_to_point_E1(proof_octets[sidx, ..., eidx])
-21.     if C_i is INVALID or Identity_G1, return INVALID
-22.     if subgroup_check_G1(C_i) returns INVALID, return INVALID
+32. commitments_proof = ((C_1, ..., C_N), (s_1, ..., s_N))
 
-23. for i in (1..N)
-24.     sidx = eidx + 1
-25.     eidx = sidx + octet_scalar_length
-26.     s_i = OS2IP(proof_octets[sidx, ..., eidx])
-27.     if s_i = 0 or if s_i >= r, return INVALID
+33. for i in (1..K)
+34.     sidx = eidx + 1
+35.     eidx = sidx + octet_point_length - 1
+36.     PK~_i = BBS.octets_to_point_E1(proof_octets[sidx, ..., eidx])
+37.     if PK~_i is INVALID or Identity_G1, return INVALID
+38.     if subgroup_check_G1(PK~_i) returns INVALID, return INVALID
 
-28. commitments_proof = ((C_1, ..., C_N), (s_1, ..., s_N))
+39. for i in (1..K)
+40.     sidx = eidx + 1
+41.     eidx = sidx + Sig.signature_length - 1
+42.     keybind_signature_i = proof_octets[sidx, ..., eidx]
+43. keybind_proof = ((PK_1, ..., PK_K),
+                    (keybind_signature_1, ..., keybind_signature_K))
 
-29. if length(proof_octets) not equal to eidx, return INVALID
-30. return (bbs_proof, commitments_proof)
+44. if length(proof_octets) not equal to eidx, return INVALID
+45. return (bbs_proof, commitments_proof, keybind_proof)
 ```
 
 # Privacy Considerations
@@ -1379,7 +1977,7 @@ In the proof sent from the Prover to the Verifier the number of committed messag
 
 ## Input Validity Checks
 
-Applications using `CoreProofGen` (as defined in (#core-proof-generation)) only as a subroutine of `BlindProofGen` (as defined in (#proof-generation)), or `CoreProofVerify` (as defined in (#core-proof-verification)) only as a subroutine of `BlindProofVerify` (as defined in (#proof-verification)), can skip the checks of the `commitment_indexes` and `disclosed_indexes` inputs performed in the corresponding core operation, since the inputs provided by the calling operation will always have the correct form. However, if applications intend to use either core operation in different contexts, those checks must be applied.
+Applications using `CoreProofGenInit` (as defined in (#core-proof-generation-initialization)) only as a subroutine of `BlindProofGen` (as defined in (#proof-generation)), or `CoreProofVerify` (as defined in (#core-proof-verification)) only as a subroutine of `BlindProofVerify` (as defined in (#proof-verification)), can skip the checks of the `commitment_indexes` and `disclosed_indexes` inputs performed in the corresponding core operation, since the inputs provided by the calling operation will always have the correct form. However, if applications intend to use either core operation in different contexts, those checks must be applied.
 
 # Security Considerations
 
@@ -1396,6 +1994,115 @@ One natural use case for the blind signatures extension of the BBS scheme is key
 # Ciphersuites
 
 This document uses the `BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_` and `BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_` defined in [@!I-D.irtf-cfrg-bbs-signatures, section 7.2.1] and [@!I-D.irtf-cfrg-bbs-signatures, section 7.2.2] correspondingly.
+
+## `BBS-SCHNORR_BLS12381G1_XMD:SHA-256_SSWU_RO_`
+
+`BBS-SCHNORR_BLS12381G1_XMD:SHA-256_SSWU_RO_` is identical to the `BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_` ciphersuite defined in [@!I-D.irtf-cfrg-bbs-signatures, section 7.2.2],
+except the suite ID (and therefore `api_id`) is different
+and for the addition of the key binding signature scheme `Sig` described in (#scheme-definition) defined as follows:
+
+TODO: Survey existing implementations for compatibility concerns:
+
+- Generator
+- Point serialization
+- Hash function
+
+```
+Sig.KeyGen(Hk) -> (SK, PK)
+1. Sample a uniformly random scalar SK by some unspecified procedure.
+2. PK = SK * Hk
+3. return (SK, PK)
+
+Sig.Sign(Hk, SK, message) -> sig
+1. (k~) = BBS.calculate_random_scalars(1)
+2. R = k~ * Hk
+3. c = OS2IP(SHA-256(BBS.serialize((R)) || message))
+4. if c >= r, goto step 1
+5. k^ = k~ + SK * c mod r
+6. return BBS.serialize((k^, c))
+
+Sig.Verify(Hk, PK, sig, message) -> VALID or INVALID
+1. if length(sig) != 2 * octet_scalar_length, return INVALID
+2. s = OS2IP(sig[0..(octet_scalar_length - 1)])
+3. c = OS2IP(sig[octet_scalar_length..(2*octet_scalar_length - 1)])
+4. if s >= r or c >= r, return INVALID
+5. R = s * Hk - c * PK
+6. cv = OS2IP(SHA-256(BBS.serialize((R)) || message))
+7. if cv >= r, return INVALID
+8. return VALID if c == cv, otherwise INVALID
+
+Sig.AdaptSig(sig, r_key, message) -> sig'
+1. if length(sig) != 2 * octet_scalar_length, return INVALID
+2. s = OS2IP(sig[0..(octet_scalar_length - 1)])
+3. c = OS2IP(sig[octet_scalar_length..(2*octet_scalar_length - 1)])
+4. if s >= r or c >= r, return INVALID
+5. return BBS.serialize((s + c * r_key mod r, c))
+
+Sig.signature_length = 64
+```
+
+## `BBS-BLS_BLS12381G1_XMD:SHA-256_SSWU_RO_`
+
+`BBS-BLS_BLS12381G1_XMD:SHA-256_SSWU_RO_` is identical to the `BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_` ciphersuite defined in [@!I-D.irtf-cfrg-bbs-signatures, section 7.2.2],
+except the suite ID (and therefore `api_id`) is different
+and for the addition of the key binding signature scheme `Sig` described in (#scheme-definition) defined as follows:
+
+TODO: Reference draft-irtf-cfrg-bls-signature for this
+
+```
+Sig.KeyGen(Hk) -> (SK, PK)
+1. Sample a uniformly random scalar SK by some unspecified procedure.
+2. PK = SK * Hk
+3. return (SK, PK)
+
+Sig.Sign(Hk, SK, message) -> sig
+1. R = hash_to_curve_G2(message)
+2. return BBS.serialize(SK * R)
+
+Sig.Verify(Hk, PK, sig, message) -> VALID or INVALID
+1. S = octets_to_point_E2(sig)
+2. if S is INVALID, return INVALID
+3. return VALID if h(Hk, S) == h(PK, hash_to_curve_G2(message)), otherwise INVALID
+
+Sig.AdaptSig(sig, r_key, message) -> sig'
+1. S = octets_to_point_E2(sig)
+2. if S is INVALID, return INVALID
+3. return BBS.serialize((S + r_key * hash_to_curve_G2(message)))
+
+Sig.signature_length = 96
+```
+
+This ciphersuite also supports "Blind BLS" signatures for key binding.
+"Blind BLS" splits out a `BlindSign` operation from `Sign` as follows:
+
+```
+Sig.Sign(Hk, SK_ref, message) -> sig
+1. R = hash_to_curve_G2(message)
+2. Sample a uniformly random scalar bst by some unspecified procedure.
+3. Rbar = bst * R
+
+4. Sbar = Sig.BlindSign(SK_ref, Rbar)
+
+5. S = Sbar * bst^-1
+6. return BBS.serialize(S)
+
+
+Sig.BlindSign(SK_ref, Rbar) -> Sbar
+1. SK = lookup(SK_ref)
+2. return SK * Rbar
+```
+
+The purpose of this is that `Sign` can be executed by a party
+that knows some identifier `SK_ref` but not the actual private key `SK`,
+and `BlindSign` is executed by a separate party that does know `SK`
+but which the first party does not want to reveal `message` to.
+Instead, `BlindSign` signs a blinded message commitment
+which `Sign` unblinds before adding it as a key binding signature.
+
+Signatures created in this way are indistinguishable from those created by the default procedure.
+Implementations MAY therefore choose freely between these variants of `Sig.Sign`
+without affecting interoperability with `BlindProofGenFinalize` and `BlindProofVerify`.
+
 
 # Test Vectors
 
@@ -2594,6 +3301,16 @@ This document does not make any requests of IANA.
   <author surname="Lehmann" fullname="Anja Lehmann" />
   <author surname="Sidorenko" fullname="Andrey Sidorenko" />
   <author surname="Zacharakis" fullname="Alexandros Zacharakis" />
+  <date year="2025" />
+  </front>
+</reference>
+<reference anchor="DBAC2025" target="https://eprint.iacr.org/2025/1995">
+  <front>
+  <title>Device-Bound Anonymous Credentials With(out) Trusted Hardware</title>
+  <author surname="Friedrichs" fullname="Karla Friedrichs" />
+  <author surname="Harding" fullname="Franklin Harding" />
+  <author surname="Lehmann" fullname="Anja Lehmann" />
+  <author surname="Lysyanskaya" fullname="Anna Lysyanskaya" />
   <date year="2025" />
   </front>
 </reference>


### PR DESCRIPTION
As [outlined on the CFRG list](https://mailarchive.ietf.org/arch/msg/cfrg/o9prj66xwrsGvRlCWmEMgjBF_28/), these are the changes that would be needed to accommodate native device binding in Blind BBS. This is compatible with BBS-Schnorr, BBS-BLS and BBS-BlindBLS as described in ["Device-Bound Anonymous Credentials With(out) Trusted Hardware"](https://eprint.iacr.org/2025/1995). BBS-Schnorr and BBS-BLS are defined as a separate ciphersuites from the base `BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_` suite, and BBS-BlindBLS is a compatible implementation variant of BBS-BLS.

A couple of notable differences from the outline on the list:

- This no longer computes an aggregated `Y` value in `CoreProofGenInit` and `CoreProofVerify`, instead it commits to all of the randomized key binding public keys by adding them explicitly into the challenge hash `commitment_arr` in `ProofChallengeCalculate`.
- `BlindProofGenKeyProve` is replaced with a more comprehensive `Sig` abstraction that's part of the ciphersuite.
- Schnorr and BLS key binding keys can no longer coexist in the same BBS credential, as the ciphersuite now commits to a specific `Sig` scheme for all key binding keys. This is to avoid having to define algorithm identifiers to tag each key binding key with its signature type. (This is only relevant if we decide to allow more than 1 key binding key)

Let us discuss if this belongs in the Blind BBS draft or as a standalone document. This is a first draft and not ready to merge, for example I'm not sure about the current approach for the `Sig` abstraction in section 4 (Scheme Definition).